### PR TITLE
fix: get sub-items from level 3 and onwards. E…

### DIFF
--- a/backend/src/guided-development.ts
+++ b/backend/src/guided-development.ts
@@ -51,11 +51,31 @@ export class GuidedDevelopment {
             if (subItem.fqid === itemFqid) {
               return subItem;
             }  
+            else if( subItem.items ){
+              const deepSubitem =  this.getDeepSubitem(itemFqid, subItem);
+              if(deepSubitem){
+                return deepSubitem;
+              }
+            }
           }
         }
       }
     }
     // TODO - console log: item does not exist
+  }
+
+  private getDeepSubitem( itemFqId: string, item:IInternalItem ): IInternalItem{
+    
+    if( item.items ){
+      for (const subItem of item.items) {
+        if (subItem.fqid === itemFqId) {
+          return subItem;
+        } else if(subItem.items){
+            return this.getDeepSubitem(itemFqId, subItem);
+        } 
+      }
+    }
+
   }
 
   private async performAction(itemFqid: string, index: number, context?: ItemContext) {

--- a/backend/tests/guided-development.spec.ts
+++ b/backend/tests/guided-development.spec.ts
@@ -196,6 +196,48 @@ describe('guidedDevelopment unit test', () => {
             expect(foundSubItem.fqid).to.equal(fqid1);
         });
 
+        it("return subSubItem", async () => {
+            const fqid1 = "extName1.extPublisher1.id1";
+            const item1: IInternalItem = {
+                id: "id1",
+                fqid: fqid1,
+                description: "description1",
+                title: "title1",
+                labels: []
+            };
+            const fqid2 = "extName1.extPublisher1.id2";
+            const item2: IInternalItem = {
+                id: "id2",
+                fqid: fqid2,
+                description: "description2",
+                title: "title2",
+                labels: [],
+                items: [item1]
+            };
+            const fqid3 = "extName1.extPublisher1.id3";
+            const item3: IInternalItem = {
+                id: "id3",
+                fqid: fqid3,
+                description: "description3",
+                title: "title2",
+                labels: [],
+                items: [item2]
+            };
+            const collection1: IInternalCollection = {
+                id: "id1",
+                title: "title1",
+                description: "description1",
+                itemIds: [],
+                type: CollectionType.Platform,
+                items: [item3]
+            };
+            await guidedDevelopment["setCollections"]([collection1]);
+            const foundItem = guidedDevelopment["getItem"](fqid3);
+            expect(foundItem.fqid).to.equal(fqid3);
+            const foundSubItem = guidedDevelopment["getItem"](fqid1);
+            expect(foundSubItem.fqid).to.equal(fqid1);
+        });
+
         it("subItem doen't contain fqid or item doesn't exist", async () => {
             const fqid1 = "extName1.extPublisher1.id1";
             const item1: IInternalItem = {


### PR DESCRIPTION
…arlier, it was limited to 2

Guided Dev tool was not returning the (sub)items which were at level 3 or beyond. Those items were
shown in the UI